### PR TITLE
Add Optional Monit Monitoring

### DIFF
--- a/roles/app_server/tasks/main.yml
+++ b/roles/app_server/tasks/main.yml
@@ -30,6 +30,9 @@
             dest={{app_path}}/config/unicorn.rb
   tags: [configure_unicorn]
 
+- include: monit_unicorn_install.yml
+  when: use_monit
+
 - name: Set up db config
   template: src=database.yml.j2 dest={{app_path}}/config/database.yml
   
@@ -87,18 +90,8 @@
   file: state=directory path={{app_path}}/tmp/unicorn owner=deployer
   tags: [deploy]
 
-- name: reload unicorn
-  sudo_upstart: name=unicorn_{{app_name}} state=reloaded
-  remote_user: deployer
-  tags: [deploy, unicorn_reload]
-  when: (app_checkout is defined and app_checkout.changed) or force_unicorn_reload
+- include: upstart_unicorn.yml
+  when: not use_monit
 
-- name: restart unicorn
-  sudo_upstart: name=unicorn_{{app_name}} state=restarted
-  tags: [unicorn_restart]
-  when: force_unicorn_restart
-
-- name: Ensure unicorn is running
-  sudo_upstart: name=unicorn_{{app_name}} state=started
-  remote_user: deployer
-  tags: [unicorn_start]
+- include: monit_unicorn.yml
+  when: use_monit

--- a/roles/app_server/tasks/monit_unicorn.yml
+++ b/roles/app_server/tasks/monit_unicorn.yml
@@ -1,0 +1,18 @@
+- name: reload unicorn
+  monit: name=unicorn_{{app_name}} state=reloaded
+  sudo: true
+  remote_user: deployer
+  tags: [deploy, unicorn_reload]
+  when: (app_checkout is defined and app_checkout.changed) or force_unicorn_reload
+
+- name: restart unicorn
+  monit: name=unicorn_{{app_name}} state=restarted
+  sudo: true
+  tags: [unicorn_restart]
+  when: force_unicorn_restart
+
+- name: Ensure unicorn is running
+  monit: name=unicorn_{{app_name}} state=started
+  sudo: true
+  remote_user: deployer
+  tags: [unicorn_start]

--- a/roles/app_server/tasks/monit_unicorn_install.yml
+++ b/roles/app_server/tasks/monit_unicorn_install.yml
@@ -1,0 +1,9 @@
+- name: Copy the unicorn service files
+  template:
+    src: "etc_monit_conf.d_unicorn.j2"
+    dest: "/etc/monit/conf.d/unicorn"
+
+- name: Restart monit
+  service:
+    name: monit
+    state: reloaded

--- a/roles/app_server/tasks/upstart_unicorn.yml
+++ b/roles/app_server/tasks/upstart_unicorn.yml
@@ -1,0 +1,15 @@
+- name: reload unicorn
+  sudo_upstart: name=unicorn_{{app_name}} state=reloaded
+  remote_user: deployer
+  tags: [deploy, unicorn_reload]
+  when: (app_checkout is defined and app_checkout.changed) or force_unicorn_reload
+
+- name: restart unicorn
+  sudo_upstart: name=unicorn_{{app_name}} state=restarted
+  tags: [unicorn_restart]
+  when: force_unicorn_restart
+
+- name: Ensure unicorn is running
+  sudo_upstart: name=unicorn_{{app_name}} state=started
+  remote_user: deployer
+  tags: [unicorn_start]

--- a/roles/app_server/templates/etc_monit_conf.d_unicorn.j2
+++ b/roles/app_server/templates/etc_monit_conf.d_unicorn.j2
@@ -1,0 +1,5 @@
+check process unicorn_{{ app_name }} with pidfile {{app_path}}/tmp/unicorn.pid
+  start program = "/sbin/start unicorn_{{ app_name }}"
+  stop program = "/sbin/stop unicorn_{{ app_name }}"
+  if 5 restarts within 5 cycles then timeout
+

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -29,4 +29,4 @@
                  state=present
 
 - include: monit.yml
-  when: use_monit is defined and use_monit
+  when: use_monit

--- a/roles/database/tasks/main.yml
+++ b/roles/database/tasks/main.yml
@@ -27,3 +27,6 @@
   postgresql_db: owner=deployer
                  name="{{ app_name }}_{{app_env}}"
                  state=present
+
+- include: monit.yml
+  when: use_monit is defined and use_monit

--- a/roles/database/tasks/monit.yml
+++ b/roles/database/tasks/monit.yml
@@ -8,5 +8,5 @@
     name: monit
     state: reloaded
 
-- name: Ensure monitoring
+- name: Ensure postgres monitoring
   monit: name=postgres state=monitored

--- a/roles/database/tasks/monit.yml
+++ b/roles/database/tasks/monit.yml
@@ -1,0 +1,12 @@
+- name: Copy the postgres service files
+  template:
+    src: "etc_monit_conf.d_postgres.j2"
+    dest: "/etc/monit/conf.d/postgres"
+
+- name: Restart monit
+  service:
+    name: monit
+    state: reloaded
+
+- name: Ensure monitoring
+  monit: name=postgres state=monitored

--- a/roles/database/templates/etc_monit_conf.d_postgres.j2
+++ b/roles/database/templates/etc_monit_conf.d_postgres.j2
@@ -1,0 +1,9 @@
+check process postgres with pidfile /var/postgres/postmaster.pid
+  group database
+  start program = "/etc/init.d/postgresql start"
+  stop  program = "/etc/init.d/postgresql stop"
+  if failed unixsocket /var/run/postgresql/.s.PGSQL.5432 protocol pgsql
+    then restart
+  if failed host 192.168.1.1 port 5432 protocol pgsql
+    then restart
+  if 5 restarts within 5 cycles then timeout

--- a/roles/database/templates/etc_monit_conf.d_postgres.j2
+++ b/roles/database/templates/etc_monit_conf.d_postgres.j2
@@ -4,6 +4,4 @@ check process postgres with pidfile /var/postgres/postmaster.pid
   stop  program = "/etc/init.d/postgresql stop"
   if failed unixsocket /var/run/postgresql/.s.PGSQL.5432 protocol pgsql
     then restart
-  if failed host 192.168.1.1 port 5432 protocol pgsql
-    then restart
   if 5 restarts within 5 cycles then timeout

--- a/roles/delayed_job/tasks/main.yml
+++ b/roles/delayed_job/tasks/main.yml
@@ -9,6 +9,9 @@
   when: dj_runner_installation.changed
   tags: [configure_dj_runner]
 
+- include: monit_dj_install.yml
+  when: use_monit
+
 - name: Give deployer user access to DJ upstart jobs
   lineinfile: 'dest=/etc/sudoers
                state=present
@@ -21,11 +24,8 @@
     - reload
   tags: [configure_dj_runner]
 
-- name: restart delayed job runner
-  sudo_upstart: name=dj_runner_{{app_name}} state=restarted
-  remote_user: "{{deployer_user}}"
-  when: force_dj_runner_restart or
-        (dj_runner_installation is defined and dj_runner_installation.changed) or
-        force_db_reset or
-        (app_checkout is defined and app_checkout.changed)
-  tags: [configure_dj_runner, deploy, reset_db]
+- include: upstart_delayed_job.yml
+  when: not use_monit
+
+- include: monit_delayed_job.yml
+  when: use_monit

--- a/roles/delayed_job/tasks/monit_delayed_job.yml
+++ b/roles/delayed_job/tasks/monit_delayed_job.yml
@@ -1,0 +1,9 @@
+- name: restart delayed job runner
+  monit: name=dj_runner_{{app_name}} state=restarted
+  sudo: true
+  remote_user: deployer_user
+  when: force_dj_runner_restart or
+        (dj_runner_installation is defined and dj_runner_installation.changed) or
+        force_db_reset or
+        (app_checkout is defined and app_checkout.changed)
+  tags: [configure_dj_runner, deploy, reset_db]

--- a/roles/delayed_job/tasks/monit_dj_install.yml
+++ b/roles/delayed_job/tasks/monit_dj_install.yml
@@ -1,0 +1,9 @@
+- name: Copy the unicorn service files
+  template:
+    src: "etc_monit_conf.d_delayed_job.j2"
+    dest: "/etc/monit/conf.d/delayed_job"
+
+- name: Restart monit
+  service:
+    name: monit
+    state: reloaded

--- a/roles/delayed_job/tasks/upstart_delayed_job.yml
+++ b/roles/delayed_job/tasks/upstart_delayed_job.yml
@@ -1,0 +1,8 @@
+- name: restart delayed job runner
+  sudo_upstart: name=dj_runner_{{app_name}} state=restarted
+  remote_user: "{{deployer_user}}"
+  when: force_dj_runner_restart or
+        (dj_runner_installation is defined and dj_runner_installation.changed) or
+        force_db_reset or
+        (app_checkout is defined and app_checkout.changed)
+  tags: [configure_dj_runner, deploy, reset_db]

--- a/roles/delayed_job/templates/etc_monit_conf.d_delayed_job.j2
+++ b/roles/delayed_job/templates/etc_monit_conf.d_delayed_job.j2
@@ -1,0 +1,5 @@
+check process dj_runner_{{ app_name }} with pidfile {{app_path}}/tmp/pids/delayed_job_0.pid
+  start program = "start dj_runner_{{ app_name }}"
+  stop program = "stop dj_runner_{{ app_name }}"
+  if 5 restarts within 5 cycles then timeout
+

--- a/roles/deployer_user/tasks/main.yml
+++ b/roles/deployer_user/tasks/main.yml
@@ -10,4 +10,4 @@
 - include: keys.yml
 
 - include: monit.yml
-  when: use_monit is defined and use_monit
+  when: use_monit

--- a/roles/deployer_user/tasks/main.yml
+++ b/roles/deployer_user/tasks/main.yml
@@ -8,3 +8,6 @@
   file: path=/home/deployer state=directory owner=deployer
 
 - include: keys.yml
+
+- include: monit.yml
+  when: use_monit is defined and use_monit

--- a/roles/deployer_user/tasks/monit.yml
+++ b/roles/deployer_user/tasks/monit.yml
@@ -1,0 +1,4 @@
+- name: Give deployer user access to unicorn upstart jobs
+  lineinfile: 'dest=/etc/sudoers
+               state=present
+               line="{{deployer_user}} ALL = (root) NOPASSWD: /usr/bin/monit"'

--- a/roles/monit/defaults/main.yml
+++ b/roles/monit/defaults/main.yml
@@ -1,0 +1,28 @@
+monit_notify_email: "me@localhost"
+
+monit_logfile: "syslog facility log_daemon"
+
+monit_poll_period: 60
+monit_poll_start_delay: 120
+
+monit_eventqueue_directory: "/var/lib/monit/events"
+monit_eventque_slots: 100
+
+monit_mailformat_from: "monit@{{inventory_hostname}}"
+monit_mailformat_subject: "$SERVICE $EVENT"
+monit_mailformat_message: "Monit $ACTION $SERVICE at $DATE on $HOST: $DESCRIPTION."
+
+monit_mailserver_host: "localhost"
+# monit_mailserver_port:
+# monit_mailserver_username:
+# monit_mailserver_password:
+# monit_mailserver_encryption:
+monit_mailserver_timeout: 60
+
+monit_port: 3737
+monit_address: "localhost"
+monit_allow: ["localhost"]
+# monit_username:
+# monit_password:
+monit_ssl: no
+monit_cert: "/etc/monit/monit.pem"

--- a/roles/monit/handlers/main.yml
+++ b/roles/monit/handlers/main.yml
@@ -1,0 +1,2 @@
+- name: restart monit
+  service: name=monit state=restarted

--- a/roles/monit/tasks/main.yml
+++ b/roles/monit/tasks/main.yml
@@ -1,0 +1,8 @@
+- name: Ensure latest monit is installed
+  apt: name=monit state=latest
+
+- name: Update monit configuration (/etc/monit/monitrc)
+  template:
+    src: "etc_monit_monitrc.j2"
+    dest: "/etc/monit/monitrc"
+  notify: restart monit

--- a/roles/monit/templates/etc_monit_monitrc.j2
+++ b/roles/monit/templates/etc_monit_monitrc.j2
@@ -1,0 +1,177 @@
+###############################################################################
+## Monit control file
+###############################################################################
+##
+## Comments begin with a '#' and extend through the end of the line. Keywords
+## are case insensitive. All path's MUST BE FULLY QUALIFIED, starting with '/'.
+##
+## Below you will find examples of some frequently used statements. For
+## information about the control file and a complete list of statements and
+## options, please have a look in the Monit manual.
+##
+##
+###############################################################################
+## Global section
+###############################################################################
+
+set daemon {{monit_poll_period}}
+{% if monit_poll_start_delay is defined %}
+  with start delay {{monit_poll_start_delay}}
+{% endif %}
+
+set logfile {{monit_logfile}}
+
+set idfile /var/lib/monit/id
+
+set statefile /var/lib/monit/state
+
+set mailserver {{monit_mailserver_host}}{% if monit_mailserver_port is defined %} port {{monit_mailserver_port}}{% endif %}
+
+{% if monit_mailserver_username is defined %}  username "{{monit_mailserver_username}}"{{'\n'}}{% endif %}
+{% if monit_mailserver_password is defined %}  password "{{monit_mailserver_password}}"{{'\n'}}{% endif %}
+{% if monit_mailserver_encryption is defined %}  using {{monit_mailserver_encryption}}{{'\n'}}{% endif %}
+{% if monit_mailserver_timeout is defined %}  with timeout {{monit_mailserver_timeout}} seconds{{'\n'}}{% endif %}
+
+set eventqueue
+  basedir {{monit_eventqueue_directory}}
+  slots {{monit_eventqueue_slots | default('100')}}
+
+set mail-format {
+  from: {{monit_mailformat_from}}
+  subject: {{monit_mailformat_subject}}
+  message: {{monit_mailformat_message}}
+}
+
+set alert {{monit_notify_email}} NOT ON { action, instance, pid, ppid }
+
+set httpd port {{monit_port}}
+{% if monit_address is defined %}  use address {{monit_address}}{{'\n'}}{% endif %}
+{% for a in monit_allow %}  allow {{a}}{{'\n'}}{% endfor %}
+{% if monit_ssl %}  ssl enable
+  pemfile {{monit_cert}}
+{% endif %}
+
+
+###############################################################################
+## Services
+###############################################################################
+##
+## Check general system resources such as load average, cpu and memory
+## usage. Each test specifies a resource, conditions and the action to be
+## performed should a test fail.
+#
+#  check system myhost.mydomain.tld
+#    if loadavg (1min) > 4 then alert
+#    if loadavg (5min) > 2 then alert
+#    if memory usage > 75% then alert
+#    if swap usage > 25% then alert
+#    if cpu usage (user) > 70% then alert
+#    if cpu usage (system) > 30% then alert
+#    if cpu usage (wait) > 20% then alert
+#
+#
+## Check if a file exists, checksum, permissions, uid and gid. In addition
+## to alert recipients in the global section, customized alert can be sent to
+## additional recipients by specifying a local alert handler. The service may
+## be grouped using the GROUP option. More than one group can be specified by
+## repeating the 'group name' statement.
+#
+#  check file apache_bin with path /usr/local/apache/bin/httpd
+#    if failed checksum and
+#       expect the sum 8f7f419955cefa0b33a2ba316cba3659 then unmonitor
+#    if failed permission 755 then unmonitor
+#    if failed uid root then unmonitor
+#    if failed gid root then unmonitor
+#    alert security@foo.bar on {
+#           checksum, permission, uid, gid, unmonitor
+#        } with the mail-format { subject: Alarm! }
+#    group server
+#
+#
+## Check that a process is running, in this case Apache, and that it respond
+## to HTTP and HTTPS requests. Check its resource usage such as cpu and memory,
+## and number of children. If the process is not running, Monit will restart
+## it by default. In case the service is restarted very often and the
+## problem remains, it is possible to disable monitoring using the TIMEOUT
+## statement. This service depends on another service (apache_bin) which
+## is defined above.
+#
+#  check process apache with pidfile /usr/local/apache/logs/httpd.pid
+#    start program = "/etc/init.d/httpd start" with timeout 60 seconds
+#    stop program  = "/etc/init.d/httpd stop"
+#    if cpu > 60% for 2 cycles then alert
+#    if cpu > 80% for 5 cycles then restart
+#    if totalmem > 200.0 MB for 5 cycles then restart
+#    if children > 250 then restart
+#    if loadavg(5min) greater than 10 for 8 cycles then stop
+#    if failed host www.tildeslash.com port 80 protocol http
+#       and request "/somefile.html"
+#       then restart
+#    if failed port 443 type tcpssl protocol http
+#       with timeout 15 seconds
+#       then restart
+#    if 3 restarts within 5 cycles then timeout
+#    depends on apache_bin
+#    group server
+#
+#
+## Check filesystem permissions, uid, gid, space and inode usage. Other services,
+## such as databases, may depend on this resource and an automatically graceful
+## stop may be cascaded to them before the filesystem will become full and data
+## lost.
+#
+#  check filesystem datafs with path /dev/sdb1
+#    start program  = "/bin/mount /data"
+#    stop program  = "/bin/umount /data"
+#    if failed permission 660 then unmonitor
+#    if failed uid root then unmonitor
+#    if failed gid disk then unmonitor
+#    if space usage > 80% for 5 times within 15 cycles then alert
+#    if space usage > 99% then stop
+#    if inode usage > 30000 then alert
+#    if inode usage > 99% then stop
+#    group server
+#
+#
+## Check a file's timestamp. In this example, we test if a file is older
+## than 15 minutes and assume something is wrong if its not updated. Also,
+## if the file size exceed a given limit, execute a script
+#
+#  check file database with path /data/mydatabase.db
+#    if failed permission 700 then alert
+#    if failed uid data then alert
+#    if failed gid data then alert
+#    if timestamp > 15 minutes then alert
+#    if size > 100 MB then exec "/my/cleanup/script" as uid dba and gid dba
+#
+#
+## Check directory permission, uid and gid.  An event is triggered if the
+## directory does not belong to the user with uid 0 and gid 0.  In addition,
+## the permissions have to match the octal description of 755 (see chmod(1)).
+#
+#  check directory bin with path /bin
+#    if failed permission 755 then unmonitor
+#    if failed uid 0 then unmonitor
+#    if failed gid 0 then unmonitor
+#
+#
+## Check a remote host availability by issuing a ping test and check the
+## content of a response from a web server. Up to three pings are sent and
+## connection to a port and an application level network check is performed.
+#
+#  check host myserver with address 192.168.1.1
+#    if failed icmp type echo count 3 with timeout 3 seconds then alert
+#    if failed port 3306 protocol mysql with timeout 15 seconds then alert
+#    if failed url http://user:password@www.foo.bar:8080/?querystring
+#       and content == 'action="j_security_check"'
+#       then alert
+#
+#
+###############################################################################
+## Includes
+###############################################################################
+##
+## It is possible to include additional configuration parts from other files or
+## directories.
+#
+   include /etc/monit/conf.d/*

--- a/roles/web/handlers/initd_restart.yml
+++ b/roles/web/handlers/initd_restart.yml
@@ -1,0 +1,2 @@
+- name: restart nginx
+  service: name=nginx state=restarted

--- a/roles/web/handlers/main.yml
+++ b/roles/web/handlers/main.yml
@@ -1,2 +1,5 @@
-- name: restart nginx
-  service: name=nginx state=restarted
+- include: monit_restart.yml
+  when: use_monit is defined and use_monit
+
+- include: initd_restart.yml
+  when: not use_monit

--- a/roles/web/handlers/main.yml
+++ b/roles/web/handlers/main.yml
@@ -1,5 +1,5 @@
 - include: monit_restart.yml
-  when: use_monit is defined and use_monit
+  when: use_monit
 
 - include: initd_restart.yml
   when: not use_monit

--- a/roles/web/handlers/monit_restart.yml
+++ b/roles/web/handlers/monit_restart.yml
@@ -1,0 +1,2 @@
+- name: restart nginx
+  monit: name=nginx state=restarted

--- a/roles/web/tasks/main.yml
+++ b/roles/web/tasks/main.yml
@@ -12,7 +12,7 @@
   tags: [nginx]
 
 - include: monit.yml
-  when: use_monit is defined and use_monit
+  when: use_monit
 
 - name: Ditch default nginx site enabled
   file: path=/etc/nginx/sites-enabled/default state=absent
@@ -58,4 +58,4 @@
 
 - name: Ensure nginx is monitored
   monit: name=nginx state=monitored
-  when: use_monit is defined and use_monit
+  when: use_monit

--- a/roles/web/tasks/main.yml
+++ b/roles/web/tasks/main.yml
@@ -11,6 +11,9 @@
   notify: restart nginx
   tags: [nginx]
 
+- include: monit.yml
+  when: use_monit is defined and use_monit
+
 - name: Ditch default nginx site enabled
   file: path=/etc/nginx/sites-enabled/default state=absent
   tags: [nginx]
@@ -52,3 +55,7 @@
   remote_user: deployer
   service: name=nginx state=running
   tags: [deploy, fe]
+
+- name: Ensure nginx is monitored
+  monit: name=nginx state=monitored
+  when: use_monit is defined and use_monit

--- a/roles/web/tasks/monit.yml
+++ b/roles/web/tasks/monit.yml
@@ -1,0 +1,9 @@
+- name: Copy the nginx service files
+  template:
+    src: "etc_monit_conf.d_nginx.j2"
+    dest: "/etc/monit/conf.d/nginx"
+
+- name: Restart monit
+  service:
+    name: monit
+    state: reloaded

--- a/roles/web/templates/etc_monit_conf.d_nginx.j2
+++ b/roles/web/templates/etc_monit_conf.d_nginx.j2
@@ -1,0 +1,3 @@
+check process nginx with pidfile /var/run/nginx.pid
+  start program = "/etc/init.d/nginx start"
+  stop program  = "/etc/init.d/nginx stop"

--- a/site_vars.example.yml
+++ b/site_vars.example.yml
@@ -3,6 +3,7 @@ app_repo: git@github.com:user/appname.git
 fe_app_repo: git@github.com:user/fe_appname.git
 fe_app_branch: remote/branch
 fe_app: true
+use_monit: true
 dev_key_files:
   - ssh/key/dir/key.pub
   - ssh/key/dir/key.pub


### PR DESCRIPTION
To enable monit for nginx, postgres, unicorn, and delayed job define `use_monit: true` in the site variables file.  Email configuration should also be set up in the site_vars.yml file.