### PR TITLE
Ensure the deployer group exists

### DIFF
--- a/roles/deployer_user/tasks/main.yml
+++ b/roles/deployer_user/tasks/main.yml
@@ -1,10 +1,10 @@
 - name: Create deployer groups
   group: name={{ item }} state=present
-  with_items: deployer_user.groups
+  with_items: deployer_user_info.groups
 
 - name: Ensure deployer user is present and put in its groups
-  user: name={{ deployer_user.name }} groups={{ item }} state=present append=yes shell=/bin/bash
-  with_items: deployer_user.groups
+  user: name={{ deployer_user_info.name }} groups={{ item }} state=present append=yes shell=/bin/bash
+  with_items: deployer_user_info.groups
 
 # It's possible for the deployer's homedir to get created on accident by
 # a deploy script or something getting run before this.  This just ensures


### PR DESCRIPTION
When creating the unicorn upstart script, we rely on the existence of a `deployer` group. This PR makes sure it exists first, then assigns the `deployer` user to the `deployer` group.
