### PR TITLE
Removed the node version from NPM install

### DIFF
--- a/vars/defaults.yml
+++ b/vars/defaults.yml
@@ -12,7 +12,6 @@ local_dir: "{{lookup('env', 'PWD')}}"
 nvm:
   user: "{{ deployer_user.name }}"
   version: v0.4.0
-  node_version: '0.10'
 
 unicorn_workers: "{{ansible_processor_cores * 2}}"
 unicorn_sockfile: /tmp/unicorn_{{ app_name }}.sock


### PR DESCRIPTION
Fix #24.

I successfully deployed the FHI API project after changing this line, but it's possible I've missed something. This seems almost too simple to be true.