### PR TITLE
Remove uses of run_once

### DIFF
--- a/roles/database_load/tasks/db_reset.yml
+++ b/roles/database_load/tasks/db_reset.yml
@@ -5,7 +5,6 @@
   command: chdir={{ app_path }}
            bash -lc "bundle exec rake db:drop db:create RAILS_ENV={{app_env}}"
   register: db_reset
-  run_once: true
 
 - name: DB Reset Failed
   fail: msg="{{db_reset.stderr}}"

--- a/roles/database_load/tasks/main.yml
+++ b/roles/database_load/tasks/main.yml
@@ -4,7 +4,6 @@
 
 - name: Precompile Assets
   remote_user: "{{ deployer_user.name }}"
-  run_once: true
   command: chdir={{ app_path }}
            bash -lc "bundle exec rake assets:precompile RAILS_ENV={{app_env}}"
   tags: [precompile_assets, deploy]
@@ -14,7 +13,6 @@
   remote_user: "{{ deployer_user.name }}"
   command: chdir={{ app_path }}
            bash -lc "bundle exec rake db:migrate RAILS_ENV={{app_env}}"
-  run_once: true
   tags: [deploy, migrate, db_reset]
   when: (app_checkout is defined and app_checkout.changed)
         or rake.force_migrate 
@@ -24,7 +22,6 @@
   remote_user: "{{ deployer_user.name }}"
   command: chdir={{ app_path }}
            bash -lc "bundle exec rake db:seed RAILS_ENV={{app_env}}"
-  run_once: true
   tags: [deploy, seed, db_reset]
   when: (app_checkout is defined and app_checkout.changed)
         or rake.force_seed


### PR DESCRIPTION
When you are provisioning/deploying to multiple servers. run_once will run these commands on only one server

http://docs.ansible.com/playbooks_delegation.html#run-once