### PR TITLE
Installer updates

### DIFF
--- a/bin/tape
+++ b/bin/tape
@@ -37,6 +37,11 @@ opt_parser = OptionParser.new do |opts|
       options.host_pattern = p
     end
 
+  opts.on("-t", "--tags [TAGS]",
+    String, "only run plays and tasks tagged with these values") do |t|
+      options.tags = t
+    end
+
   opts.separator ''
   opts.separator "MODULES"
   TapeBoxer.registered_modules.values.each do |exec_module|

--- a/lib/tape/ansible_runner.rb
+++ b/lib/tape/ansible_runner.rb
@@ -61,6 +61,7 @@ class AnsibleRunner < ExecutionModule
     enforce_roles_path!
     cmd = "ANSIBLE_CONFIG=#{local_dir}/.tape/ansible.cfg ansible-playbook -i #{inventory_file} #{playbook} #{args} #{hosts_flag} -e tape_dir=#{tape_dir}"
     cmd += ' -vvvv' if opts.verbose
+    cmd += " -t #{opts.tags}" if opts.tags
     STDERR.puts "Executing: #{cmd}" if opts.verbose
     Kernel.exec(cmd)
   end

--- a/lib/tape/installer.rb
+++ b/lib/tape/installer.rb
@@ -20,7 +20,8 @@ module TapeBoxer
 
     def dependencies
       puts 'Dependencies:'
-      if system "ansible-galaxy install -r #{sb_dir}/requirements.yml --force"
+
+      if system "ansible-galaxy install -r #{tape_dir}/requirements.yml -p #{tape_dir}/vendor --force"
         print 'Installing/updating dependencies: '
         puts '✔'.green
       else

--- a/lib/tape/installer.rb
+++ b/lib/tape/installer.rb
@@ -2,6 +2,9 @@ module TapeBoxer
   class Installer < ExecutionModule
     TapeBoxer.register_module :installer, self
 
+    action :dependencies,
+           proc { dependencies },
+           'Install dependencies'
     action :install,
       proc {install},
       'Creates all nessisary hosts and config files'
@@ -14,9 +17,19 @@ module TapeBoxer
     end
 
     protected
+
+    def dependencies
+      puts 'Dependencies:'
+      if system "ansible-galaxy install -r #{sb_dir}/requirements.yml --force"
+        print 'Installing/updating dependencies: '
+        puts '✔'.green
+      else
+        puts '✘'.red
+      end
+    end
+
     def install
-      puts "Installing ansible galaxy roles".pink
-      `ansible-galaxy install -r #{tape_dir}/requirements.yml -p #{tape_dir}/vendor --force`
+      dependencies
       mkdir 'roles'
       copy_example 'omnibox.example.yml', 'omnibox.yml'
       copy_example 'deploy.example.yml', 'deploy.yml'


### PR DESCRIPTION
Run `tape installer dependencies` every time you install*/update _tape_

**install***: `tape installer install` will run this for you, but developers that didn't ran it on their computers need to install dependencies in order to use tape appropriately.