### PR TITLE
configure ansible to install roles locally

### DIFF
--- a/ansible.cfg
+++ b/ansible.cfg
@@ -1,0 +1,2 @@
+[defaults]
+roles_path = ~/.ansible/roles

--- a/hosts.example
+++ b/hosts.example
@@ -1,7 +1,7 @@
-// Base Example
+# Base Example
 [omnibox]
 0.0.0.0 be_app_env=SOME_ENV be_app_branch=SOME_BRANCH 
 
-// Vagrant Example
-[omnibox]
-192.168.13.37 ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key
+# Vagrant Example
+# [omnibox]
+# 192.168.13.37 ansible_ssh_private_key_file=~/.vagrant.d/insecure_private_key


### PR DESCRIPTION
Without this configuration `ansible-galaxy` will try to install roles to `/etc/ansible/roles`.