### PR TITLE
Allow custom ansible config

### DIFF
--- a/lib/taperole/core/ansible_runner.rb
+++ b/lib/taperole/core/ansible_runner.rb
@@ -62,8 +62,11 @@ module Taperole
 
     def enforce_roles_path!
       Dir.mkdir('.tape') unless Dir.exist?('.tape')
+      config_file = "#{local_dir}/.tape/ansible.cfg"
 
-      File.open("#{local_dir}/.tape/ansible.cfg", 'w') do |f|
+      return if File.exist?(config_file)
+
+      File.open(config_file, 'w') do |f|
         f.puts '[defaults]'
         f.puts "roles_path=.tape/roles:#{tape_dir}/roles:#{tape_dir}/vendor"
         f.puts "inventory=#{tapefiles_dir}/hosts"


### PR DESCRIPTION
### Why?

- Custom ansible configs were being overwritten on every deployment

### What changed? 

- Short-circuit `enforce_roles_path!` in the case where the file already exists.